### PR TITLE
Keep scroll position after replacing content

### DIFF
--- a/Resources/public/js/ajax.js
+++ b/Resources/public/js/ajax.js
@@ -24,6 +24,17 @@ $(document).ready(function() {
         });
     });
 });
+
+/**
+ * Keep scroll position after replacing content
+ */
+$(document).ajaxStart(function() {
+    scrollTop = $(document).scrollTop();
+});
+$(document).ajaxSuccess(function() {
+    $(document).scrollTop(scrollTop);
+});
+
 $(document).ajaxComplete(function() {
     $('*[data-toggle="ajax"]').each(function() {
         $(this).css({


### PR DESCRIPTION
I think it must be by default but maybe there are cases that need an option to avoid this auto scroll after ajax call. We can discuss about it....