### PR TITLE
ajax.js: Force reload to allow URL with anchor in "redirect" property

### DIFF
--- a/Resources/public/js/ajax.js
+++ b/Resources/public/js/ajax.js
@@ -221,6 +221,7 @@ function handleJson(json, update, updateStrategy, effect) {
     // redirect is an url
     if (json.hasOwnProperty("redirect")) {
         window.location = json.redirect;
+        location.reload();
     }
 }
 


### PR DESCRIPTION
I'm returning the URL of the current page with an anchor in the `redirect` property of the JSON response. So I'm on the `something` page and after form submission the redirect `something#anchor-1` is returned.

But the page is not reloaded because the browser doesn't detect that the page has changed.

According to the answers in [this Stack Overflow thread](http://stackoverflow.com/questions/10612438/javascript-reload-the-page-with-hash-value/18834633#18834633), `location.reload();` will force the reload.