### PR TITLE
fix double redirect on firefox

### DIFF
--- a/Resources/public/js/ajax.js
+++ b/Resources/public/js/ajax.js
@@ -223,8 +223,10 @@ function handleJson(json, update, updateStrategy, effect) {
     }
     // redirect is an url
     if (json.hasOwnProperty("redirect")) {
+        if (window.location == json.redirect) {
+            location.reload(true);
+        }
         window.location = json.redirect;
-        location.reload();
     }
 }
 


### PR DESCRIPTION
window.location = '/uri' dosn't stop script execution on firefox, so you could generate 2 requests to the server. In most case it's not visible but if you have flashbag messages in the response, they are send in the first response and you forget them in second response that you should see on client screen